### PR TITLE
Normalize logs

### DIFF
--- a/libraries/log/include/koinos/log.hpp
+++ b/libraries/log/include/koinos/log.hpp
@@ -31,7 +31,6 @@ void initialize_logging(
    const std::optional< std::string >& identifier = {},
    const std::string& filter_level = "info",
    const std::optional< std::filesystem::path >& log_directory = {},
-   const std::string& file_pattern = "%3N.log",
-   bool color = true );
+   bool color = false );
 
 } // koinos

--- a/libraries/log/log.cpp
+++ b/libraries/log/log.cpp
@@ -202,8 +202,8 @@ void initialize_logging(
       boost::log::add_file_log(
          boost::log::keywords::file_name = file_name,
          boost::log::keywords::target_file_name = application_name + "-%Y-%m-%dT%H-%M-%S.%N.log",
-         boost::log::keywords::rotation_size = 1 * 1024 * 1024,
-         boost::log::keywords::max_size = 100 * 1024 * 1024,
+         boost::log::keywords::rotation_size = 1 * 64,
+         boost::log::keywords::max_size = 100 * 64,
          boost::log::keywords::max_files = 100,
          boost::log::keywords::format = "%" TIMESTAMP_ATTR "% (%" SERVICE_ID_ATTR "%) [%" FILE_ATTR "%:%" LINE_ATTR "%] <%" SEVERITY_ATTR "%>: %" MESSAGE_ATTR "%",
          boost::log::keywords::auto_flush = true

--- a/libraries/log/log.cpp
+++ b/libraries/log/log.cpp
@@ -201,8 +201,8 @@ void initialize_logging(
          boost::log::keywords::file_name = log_directory.value().string() + "/" + application_name + ".log",
          boost::log::keywords::target_file_name = log_directory.value().string() + "/" + application_name + "-%Y-%m-%dT%H-%M-%S.%N.log",
          boost::log::keywords::rotation_size = 1 * 1024,
-         boost::log::keywords::max_size = 100 * 1024,
-         boost::log::keywords::max_files = 100,
+         boost::log::keywords::max_size = 10 * 1024,
+         boost::log::keywords::max_files = 10,
          boost::log::keywords::format = "%" TIMESTAMP_ATTR "% (%" SERVICE_ID_ATTR "%) [%" FILE_ATTR "%:%" LINE_ATTR "%] <%" SEVERITY_ATTR "%>: %" MESSAGE_ATTR "%",
          boost::log::keywords::auto_flush = true
       );

--- a/libraries/log/log.cpp
+++ b/libraries/log/log.cpp
@@ -195,15 +195,13 @@ void initialize_logging(
 
    if ( log_directory.has_value() )
    {
-      auto file_name = log_directory.value().string() + "/" + application_name + ".log";
-
       // Output message to file, rotates when file reached 1mb. Each log file
       // is capped at 1mb and total is 100mb and 100 files.
       boost::log::add_file_log(
-         boost::log::keywords::file_name = file_name,
-         boost::log::keywords::target_file_name = application_name + "-%Y-%m-%dT%H-%M-%S.%N.log",
-         boost::log::keywords::rotation_size = 1 * 64,
-         boost::log::keywords::max_size = 100 * 64,
+         boost::log::keywords::file_name = log_directory.value().string() + "/" + application_name + ".log",
+         boost::log::keywords::target_file_name = log_directory.value().string() + "/" + application_name + "-%Y-%m-%dT%H-%M-%S.%N.log",
+         boost::log::keywords::rotation_size = 1 * 1024,
+         boost::log::keywords::max_size = 100 * 1024,
          boost::log::keywords::max_files = 100,
          boost::log::keywords::format = "%" TIMESTAMP_ATTR "% (%" SERVICE_ID_ATTR "%) [%" FILE_ATTR "%:%" LINE_ATTR "%] <%" SEVERITY_ATTR "%>: %" MESSAGE_ATTR "%",
          boost::log::keywords::auto_flush = true

--- a/libraries/log/log.cpp
+++ b/libraries/log/log.cpp
@@ -198,8 +198,9 @@ void initialize_logging(
       // Output message to file, rotates when file reached 1mb. Each log file
       // is capped at 1mb and total is 100mb and 100 files.
       boost::log::add_file_log(
-         boost::log::keywords::file_name = log_directory.value().string() + "/" + application_name + ".log",
-         boost::log::keywords::target_file_name = log_directory.value().string() + "/" + application_name + "-%Y-%m-%dT%H-%M-%S.%N.log",
+         boost::log::keywords::file_name = log_directory->string() + "/" + application_name + ".log",
+         boost::log::keywords::target_file_name = log_directory->string() + "/" + application_name + "-%Y-%m-%dT%H-%M-%S.%f.log",
+         boost::log::keywords::target = log_directory->string(),
          boost::log::keywords::rotation_size = 1 * 1024,
          boost::log::keywords::max_size = 10 * 1024,
          boost::log::keywords::max_files = 10,

--- a/libraries/log/log.cpp
+++ b/libraries/log/log.cpp
@@ -172,7 +172,6 @@ void initialize_logging(
    const std::optional< std::string >& identifier,
    const std::string& filter_level,
    const std::optional< std::filesystem::path >& log_directory,
-   const std::string& file_pattern,
    bool color )
 {
    using console_sink       = boost::log::sinks::synchronous_sink< console_sink_impl< false > >;
@@ -196,15 +195,16 @@ void initialize_logging(
 
    if ( log_directory.has_value() )
    {
-      auto file_name = log_directory.value().string() + "/" + file_pattern;
+      auto file_name = log_directory.value().string() + "/" + application_name + ".log";
 
-      // Output message to file, rotates when file reached 1mb or at midnight every day. Each log file
-      // is capped at 1mb and total is 20mb
+      // Output message to file, rotates when file reached 1mb. Each log file
+      // is capped at 1mb and total is 100mb and 100 files.
       boost::log::add_file_log(
          boost::log::keywords::file_name = file_name,
+         boost::log::keywords::target_file_name = application_name + "-%Y-%m-%dT%H-%M-%S.%N.log",
          boost::log::keywords::rotation_size = 1 * 1024 * 1024,
-         boost::log::keywords::max_size = 20 * 1024 * 1024,
-         boost::log::keywords::time_based_rotation = boost::log::sinks::file::rotation_at_time_point( 0, 0, 0 ),
+         boost::log::keywords::max_size = 100 * 1024 * 1024,
+         boost::log::keywords::max_files = 100,
          boost::log::keywords::format = "%" TIMESTAMP_ATTR "% (%" SERVICE_ID_ATTR "%) [%" FILE_ATTR "%:%" LINE_ATTR "%] <%" SEVERITY_ATTR "%>: %" MESSAGE_ATTR "%",
          boost::log::keywords::auto_flush = true
       );

--- a/libraries/log/log.cpp
+++ b/libraries/log/log.cpp
@@ -201,9 +201,9 @@ void initialize_logging(
          boost::log::keywords::file_name = log_directory->string() + "/" + application_name + ".log",
          boost::log::keywords::target_file_name = log_directory->string() + "/" + application_name + "-%Y-%m-%dT%H-%M-%S.%f.log",
          boost::log::keywords::target = log_directory->string(),
-         boost::log::keywords::rotation_size = 1 * 1024,
-         boost::log::keywords::max_size = 10 * 1024,
-         boost::log::keywords::max_files = 10,
+         boost::log::keywords::rotation_size = 1 * 1024 * 1024,
+         boost::log::keywords::max_size = 100 * 1024 * 1024,
+         boost::log::keywords::max_files = 100,
          boost::log::keywords::format = "%" TIMESTAMP_ATTR "% (%" SERVICE_ID_ATTR "%) [%" FILE_ATTR "%:%" LINE_ATTR "%] <%" SEVERITY_ATTR "%>: %" MESSAGE_ATTR "%",
          boost::log::keywords::auto_flush = true
       );

--- a/tests/tests/log_test.cpp
+++ b/tests/tests/log_test.cpp
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE( log_color_tests )
    };
 
    auto temp = std::filesystem::temp_directory_path() / "log";
-   koinos::initialize_logging( "log_test", {}, "trace", temp, "log_test_color_%3N.log" );
+   koinos::initialize_logging( "log_test_color", {}, "trace", temp, true );
 
    LOG( trace )   << "test";
    LOG( debug )   << "test";
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE( log_color_tests )
       << boost::log::add_value("Line", __LINE__)
       << boost::log::add_value("File", boost::filesystem::path(__FILE__).filename().string()) << "test";
 
-   auto file_path = temp / "log_test_color_000.log";
+   auto file_path = temp / "log_test_color.log";
    std::ifstream file( file_path.string() );
    BOOST_REQUIRE( file.is_open() );
 
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE( log_no_color_tests )
    };
 
    auto temp = std::filesystem::temp_directory_path() / "log";
-   koinos::initialize_logging( "log_test", "9abcd", "trace", temp, "log_test_no_color_%3N.log", false /* no color */ );
+   koinos::initialize_logging( "log_test", "9abcd", "trace", temp );
 
    LOG( trace )   << "test";
    LOG( debug )   << "test";
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE( log_no_color_tests )
       << boost::log::add_value("Line", __LINE__)
       << boost::log::add_value("File", boost::filesystem::path(__FILE__).filename().string()) << "test";
 
-   auto file_path = temp / "log_test_no_color_000.log";
+   auto file_path = temp / "log_test.log";
    std::ifstream file( file_path.string() );
    BOOST_REQUIRE( file.is_open() );
 
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE( log_filter_tests )
    };
 
    auto temp = std::filesystem::temp_directory_path() / "log";
-   koinos::initialize_logging( "log_test", "9abcd", "warning", temp, "log_test_no_color_%3N.log", false /* no color */ );
+   koinos::initialize_logging( "log_test_filter", "9abcd", "warning", temp, false );
 
    LOG( trace )   << "test";
    LOG( debug )   << "test";
@@ -174,7 +174,7 @@ BOOST_AUTO_TEST_CASE( log_filter_tests )
       << boost::log::add_value("Line", __LINE__)
       << boost::log::add_value("File", boost::filesystem::path(__FILE__).filename().string()) << "test";
 
-   auto file_path = temp / "log_test_no_color_000.log";
+   auto file_path = temp / "log_test_filter.log";
    std::ifstream file( file_path.string() );
    BOOST_REQUIRE( file.is_open() );
 


### PR DESCRIPTION
Resolves koinos/koinos-internal#193.

## Brief description
Writing log files are now optional. Logs are maximum of 1MB per file and 100 files (100MB max not including active file). Format has been changed to conform to Koinos Golang log library.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
These tests were performed with 1KB max log file with 10 max file rotating backups.
```console
❯ ls -lsah
total 88
0 drwxr-xr-x  13 sgerbino  staff   416B Sep 27 16:10 .
0 drwxr-xr-x  18 sgerbino  staff   576B Sep 27 15:14 ..
8 -rw-r--r--   1 sgerbino  staff   940B Sep 27 15:46 grpc-2023-09-27T15-46-32.207545.log
8 -rw-r--r--   1 sgerbino  staff   976B Sep 27 15:49 grpc-2023-09-27T15-49-31.136583.log
8 -rw-r--r--   1 sgerbino  staff   940B Sep 27 15:51 grpc-2023-09-27T15-52-02.222339.log
8 -rw-r--r--   1 sgerbino  staff   940B Sep 27 15:54 grpc-2023-09-27T15-54-32.157143.log
8 -rw-r--r--   1 sgerbino  staff   976B Sep 27 15:57 grpc-2023-09-27T15-57-31.140779.log
8 -rw-r--r--   1 sgerbino  staff   940B Sep 27 15:59 grpc-2023-09-27T16-00-02.161990.log
8 -rw-r--r--   1 sgerbino  staff   940B Sep 27 16:02 grpc-2023-09-27T16-02-32.166481.log
8 -rw-r--r--   1 sgerbino  staff   976B Sep 27 16:05 grpc-2023-09-27T16-05-31.144778.log
8 -rw-r--r--   1 sgerbino  staff   940B Sep 27 16:07 grpc-2023-09-27T16-08-02.175677.log
8 -rw-r--r--   1 sgerbino  staff   940B Sep 27 16:10 grpc-2023-09-27T16-10-32.181559.log
8 -rw-r--r--   1 sgerbino  staff   131B Sep 27 16:10 grpc.log
```
