### PR TITLE
Fix CMAKE launcher env var and build coverage in one step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
 
 env:
   global:
-    - CMAKE_CC_COMPILER_LAUNCHER=ccache
+    - CMAKE_C_COMPILER_LAUNCHER=ccache
     - CMAKE_CXX_COMPILER_LAUNCHER=ccache
 
 jobs:
@@ -79,7 +79,6 @@ jobs:
         - mkdir build
         - cd build
         - cmake -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE=ON ..
-        - cmake --build . --config Debug --parallel 3
       script:
         - cmake --build . --config Debug --parallel 3 --target coverage
       after_success:


### PR DESCRIPTION
## Brief description

Fixes CMAKE ccache env vars and incorrect invocation of coverage. It works on libs, but breaks if there are executables. Patching it here for consistency across C++ repos.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
